### PR TITLE
Add clicks

### DIFF
--- a/pisound-btn/Makefile
+++ b/pisound-btn/Makefile
@@ -23,7 +23,7 @@ PATCHES_DIR ?= /usr/local/pisound-patches
 all: pisound-btn
 
 pisound-btn: pisound-btn.c
-	gcc-4.9 pisound-btn.c -o pisound-btn
+	gcc pisound-btn.c -o pisound-btn
 	strip pisound-btn
 
 $(PISOUND_DIR):

--- a/pisound-btn/pisound-btn.c
+++ b/pisound-btn/pisound-btn.c
@@ -1042,7 +1042,6 @@ int main(int argc, char **argv, char **envp)
 				if (parse_uint(&x, argv[i+1]))
 				{
 					g_debug = x;
-					click_count_limit_specified = true;
 					++i;
 				}
 			}


### PR DESCRIPTION
This pull request adds the ability to explicitly define more CLICK_n and HOLD_nS entries, without resorting to a single script that parses the click or hold times.

# CLICK Changes:

- Clicks CLICK_1 to CLICK_99 may be defined
- Undefined CLICK_n entries are routed to CLICK_OTHER as before
- CLICK_n  config file entries without a script definition:
  - Do not generate an error.
  - Does print an entry indicating the CLICK_n that does not have the script.
  - Does not may any system call to run a script.
- Legacy default CLICK_1, CLICK_2 CLICK_3 entries are preserved.
- If CLICK_OTHER is not defined and CLICK_n is not defined then the result is the same as CLICK_n being defined without a script entry in the config file.

# HOLD changes

- Holds HOLD_1S to HOLD_99S may be defined in odd increments (eg. HOLD_1S and HOLD_3S but not HOLD_2S)
- Undefined HOLD_nS entries are routed to HOLD_OTHER as before
- HOLD_nS config file entries without a script definition:
  - Do not generate an error.
  - Does print an entry indicating the HOLD_n that does not have the script.
  - Does not may any system call to run a script.
- Legacy default HOLD_3S and HOLD_5S entries are preserved,
- if HOLD_OTHER is not defined and HOLD_nS is not defined then the result is the same as HOLD_nS being defined without a script entry in the config file.

# UP/DOWN changes

- UP and DOWN events no longer have a default script.  They must be specified in the configuration file.

# Explicit limits

 - Explicit CLICK_n and HOLD_nS limits are defined at the top of the file.
 
